### PR TITLE
Fix missing numpy import in api main

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -18,6 +18,7 @@ import json
 from datetime import datetime
 import uvicorn
 import logging
+import numpy as np
 
 # Configuration du logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- add `numpy` import in `api/main.py`

## Testing
- `python -m py_compile api/main.py`

------
https://chatgpt.com/codex/tasks/task_e_687dffb1cfcc83289ae94e15f9fdc04b